### PR TITLE
Prevent getting error if no jobId returned

### DIFF
--- a/src/services/ReindexQueueManagementService.php
+++ b/src/services/ReindexQueueManagementService.php
@@ -78,7 +78,9 @@ class ReindexQueueManagementService extends Component
 
         $jobId = Craft::$app->queue->push($job);
 
-        $this->addJobIdToCache($jobId);
+        if ($jobId > 0) {
+            $this->addJobIdToCache($jobId);
+        }
     }
 
     /**


### PR DESCRIPTION
This patch fix an error, because of getting no jobId, if this certain queue job already exists in the queue and you use and queue "optimizer" like https://github.com/ostark/craft-relax.

